### PR TITLE
FIX: Resolve issues with Artifactory NuGet publish

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - release/*
+      - jc/add-artifactory-publish-3
   pull_request:
     branches:
       - main

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - release/*
-      - jc/add-artifactory-publish-3
   pull_request:
     branches:
       - main

--- a/.github/workflows/upload-spec.json
+++ b/.github/workflows/upload-spec.json
@@ -1,39 +1,39 @@
 {
     "files": [
         {
-            "pattern": "./src/HouseofCat.Compression/bin/Release/net8.0/*",
+            "pattern": "./src/HouseofCat.Compression/bin/Release/*",
             "target": "${NUGET_REPO}/rabbitmq/"
         },
         {
-            "pattern": "./src/HouseofCat.Data/bin/Release/net8.0/*",
+            "pattern": "./src/HouseofCat.Data/bin/Release/*",
             "target": "${NUGET_REPO}/rabbitmq/"
         },
         {
-            "pattern": "./src/HouseofCat.Dataflows/bin/Release/net8.0/*",
+            "pattern": "./src/HouseofCat.Dataflows/bin/Release/*",
             "target": "${NUGET_REPO}/rabbitmq/"
         },
         {
-            "pattern": "./src/HouseofCat.Encryption/bin/Release/net8.0/*",
+            "pattern": "./src/HouseofCat.Encryption/bin/Release/*",
             "target": "${NUGET_REPO}/rabbitmq/"
         },
         {
-            "pattern": "./src/HouseofCat.Hashing/bin/Release/net8.0/*",
+            "pattern": "./src/HouseofCat.Hashing/bin/Release/*",
             "target": "${NUGET_REPO}/rabbitmq/"
         },
         {
-            "pattern": "./src/HouseofCat.Metrics/bin/Release/net8.0/*",
+            "pattern": "./src/HouseofCat.Metrics/bin/Release/*",
             "target": "${NUGET_REPO}/rabbitmq/"
         },
         {
-            "pattern": "./src/HouseofCat.RabbitMQ/bin/Release/net8.0/*",
+            "pattern": "./src/HouseofCat.RabbitMQ/bin/Release/*",
             "target": "${NUGET_REPO}/rabbitmq/"
         },
         {
-            "pattern": "./src/HouseofCat.Serialization/bin/Release/net8.0/*",
+            "pattern": "./src/HouseofCat.Serialization/bin/Release/*",
             "target": "${NUGET_REPO}/rabbitmq/"
         },
         {
-            "pattern": "./src/HouseofCat.Utilities/bin/Release/net8.0/*",
+            "pattern": "./src/HouseofCat.Utilities/bin/Release/*",
             "target": "${NUGET_REPO}/rabbitmq/"
         }
     ]

--- a/version.props
+++ b/version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <Version>3.2.2</Version>
-    <AssemblyVersion>3.2.2</AssemblyVersion>
-    <FileVersion>3.2.2</FileVersion>
+    <Version>1.0.0</Version>
+    <AssemblyVersion>1.0.0</AssemblyVersion>
+    <FileVersion>1.0.0</FileVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Description of the change

- Fixed upload spec path for NuGet packages
- Fixed search path to find NuGet packages for upload
- Updated version to 1.0.0

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

For production level repositories:

### Development

- [ ] The code changed/added as part of this pull request has been covered with tests.
- [x] There are no secrets (passwords, api keys) or userdata in this PR.

### Code review 

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ] Issue from task tracker has a link to this pull request (Can be done automatically with [branch names or PR titles](https://support.atlassian.com/jira-software-cloud/docs/reference-issues-in-your-development-work/)).

### Security

- [x] This PR does not send user data to a new location.
- [x] This PR does not store new user data or change how we store user data.
- [x] This PR does not talk to third party services or open new network connections.

If any of these boxes can not be checked, please work with the platform team to identify any risks and ways they can be mitigated.
